### PR TITLE
SkillBox 컴포넌트 및 Skills 페이지 적용 테스트

### DIFF
--- a/src/Components/Skills/SkillBox.tsx
+++ b/src/Components/Skills/SkillBox.tsx
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef } from "react";
+import { Skill } from "../../types";
+
+interface SkillBoxProps {
+  item: Skill;
+}
+
+export default function SkillBox({ item }: SkillBoxProps) {
+  const [expanded, setExpanded] = useState(false);
+  const skillBoxRef = useRef<HTMLDivElement | null>(null);
+
+  const handleToggle = () => {
+    setExpanded(!expanded);
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      skillBoxRef.current &&
+      !skillBoxRef.current.contains(event.target as Node)
+    ) {
+      setExpanded(false);
+    }
+  };
+
+  useEffect(() => {
+    // 이벤트 리스너를 문서에 추가
+    document.addEventListener("mousedown", handleClickOutside);
+
+    // 컴포넌트가 언마운트될 때 이벤트 리스너를 제거
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []); // 빈 의존성 배열을 사용하여 마운트/언마운트 시에만 실행
+
+  return (
+    <div
+      ref={skillBoxRef}
+      className={`${
+        expanded ? "w-44 cursor-default" : "w-14 cursor-pointer"
+      } shadow-lg rounded-md transition-all duration-300 ease-in-out aspect-square flex justify-center items-center p-1`}
+      onClick={handleToggle}
+    >
+      <section className="flex flex-col items-center">
+        <img
+          src={item.icon}
+          alt={item.title}
+          className={`${expanded ? "w-14" : "w-full"} aspect-square`}
+        />
+        {expanded && (
+          <section className="flex flex-col items-center">
+            <div>{item.title}</div>
+            <div>{item.description}</div>
+          </section>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/Pages/Skills.tsx
+++ b/src/Pages/Skills.tsx
@@ -1,15 +1,9 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import DarkModeButton from "../Components/Header/DarkModeButton";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
 import useFetchCollection from "../utils/hooks/useFetchCollection"; // hook을 import합니다.
-import SkillBox from "./SkillBox"; // SkillBox 컴포넌트를 import합니다.
-
-interface Skill {
-  title: string;
-  icon: string;
-  description: string;
-}
+import SkillBox from "../Components/Skills/SkillBox"; // SkillBox 컴포넌트를 import합니다.
+import { Skill } from "../types";
 
 export default function Skills() {
   const darkMode = useDarkMode();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+export interface Skill {
+  title: string;
+  icon: string;
+  description: string;
+}


### PR DESCRIPTION
- [ ] useFetchCollection 훅을 이용해 db에서 skills 디렉토리의 정보를 모두 불러온다.
- [ ] 불러온 Skill 데이터의 타입을 정의한다.
- [ ] Skill 데이터를 SkillBox 컴포넌트의 prop으로 전달하여 UI에 렌더링한다.