### PR TITLE
fix: Nav가 열려있지 않을 때의 예외 처리 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Nav from "./Components/Header/Nav";
 function App() {
   const darkMode = useDarkMode();
   const canvasRef = useGrain(darkMode);
+
   return (
     <DarkModeWrapper>
       <canvas

--- a/src/Components/Header/Nav.tsx
+++ b/src/Components/Header/Nav.tsx
@@ -12,6 +12,8 @@ export default function Nav() {
     <motion.div
       className={`${
         darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
+      } ${
+        isOpen ? "" : "pointer-events-none"
       } flex justify-center items-center flex-col space-y-4 text-lg sm:text-xl md:text-2xl lg:text-3xl xl:text-3xl w-screen h-screen z-5 fixed transition-all duration-300 ease-in-out`}
       variants={containerVariants}
       initial="hidden"


### PR DESCRIPTION
### 발견된 이슈
- 각 페이지의 return to main 링크가 정상 동작하지 않음
  - About : 반응 없음, 커서 default
  - Skills : 커서 pointer, 스킬박스나 메인버튼 클릭 시 메뉴 표시됨 + 클릭한 위치에 따라 페이지가 about, skills, contacts 등으로 이동됨
  - Projects : 화면 중앙의 특정 영역에서 커서 pointer, 증상 상동
  - Contacts : 증상 상동하나, 하단의 return to main 동작하지 않음 (cursor default)

### 문제 파악
앱 중앙의 특정 영역 (=Nav가 표시되는 영역)에 보이지 않는 상태의 Nav 컴포넌트가 존재함. w-screen h-screen에 z-index가 5이므로 다른 요소가 클릭되지 않음
App에서 Nav가 적용된 코드를 수정할 필요 있음

###해결
AnimatePresence는 자식 컴포넌트의 생명 주기를 추적하여 언마운트될 때 exit 애니메이션을 트리거한다. 그러나 만약 isOpen 상태 값이 false로 변경될 때 자식 컴포넌트 (Nav 컴포넌트)가 즉시 언마운트되면, AnimatePresence는 애니메이션을 수행하기 전에 컴포넌트가 이미 사라진 것으로 간주하게 되어 exit 애니메이션이 트리거되지 않는다.
위의 문제로 인하여, 상기한 이슈는 Nav를 isOpen 상태에 따라 조건부 렌더링되도록 수정하는 것으로 해결 가능하지만, 그렇게 될 경우 Nav의 exit 애니메이션이 실행되지 않게 된다.
따라서 기존의 방법 (Nav를 항상 렌더링하되, isOpen 상태에 따라 visible 또는 hidden 속성을 두는 것)을 유지하는 한편, isOpen이 false일 때 pointer-events-none 속성을 추가하여 Nav에 대한 포인터 입력이 동작하지 않도록 처리한다.