### PR TITLE
feat: ProjectList와 ProjectDetails 페이지 구현 (뼈대만...)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,13 @@ import DarkModeWrapper from "./utils/DarkModeWrapper";
 import Header from "./Components/Header/Header";
 import { AnimatePresence } from "framer-motion";
 import Nav from "./Components/Header/Nav";
+import { useSelector } from "react-redux";
+import { RootState } from "./redux/store";
 
 function App() {
   const darkMode = useDarkMode();
   const canvasRef = useGrain(darkMode);
+  const isOpen = useSelector((state: RootState) => state.menu.isOpen);
 
   return (
     <DarkModeWrapper>
@@ -24,9 +27,8 @@ function App() {
         className="absolute top-0 left-0 w-full h-full z-10 opacity-5 pointer-events-none"
       />
 
-      <AnimatePresence>
-        <Nav key="nav" />
-      </AnimatePresence>
+      <AnimatePresence>{isOpen && <Nav key="nav" />}</AnimatePresence>
+
       <Header />
 
       <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { AnimatePresence } from "framer-motion";
 import Nav from "./Components/Header/Nav";
 import { useSelector } from "react-redux";
 import { RootState } from "./redux/store";
+import ProjectDetails from "./Pages/ProjectDetails";
 
 function App() {
   const darkMode = useDarkMode();
@@ -37,6 +38,7 @@ function App() {
         <Route path="/skills" element={<Skills />} />
         <Route path="/projects" element={<Projects />} />
         <Route path="/contacts" element={<Contacts />} />
+        <Route path="/projects/:id" element={<ProjectDetails />} />
       </Routes>
     </DarkModeWrapper>
   );

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
   return (
     <section
       className={`${
-        darkMode ? "text-white" : " text-gray-700"
+        darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
       } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15`}
     >
       <section className="w-40 flex justify-center items-center">

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -24,7 +24,6 @@ export default function Header() {
       </section>
       <section className="flex w-32 justify-around items-center p-5">
         <DarkModeButton />
-        {/* <section onClick={handleMenuClick}>{isOpen ? "X" : "O"}</section> */}
         <NavButton
           toggle={() => handleMenuClick()}
           isOpen={isOpen}

--- a/src/Components/Header/Nav.tsx
+++ b/src/Components/Header/Nav.tsx
@@ -1,23 +1,18 @@
 import { motion } from "framer-motion";
 import NavItem from "./NavItem";
-import { useSelector } from "react-redux/es/hooks/useSelector";
-import { RootState } from "../../redux/store";
 import { useDarkMode } from "../../utils/hooks/useDarkMode";
 
 export default function Nav() {
-  const isOpen = useSelector((state: RootState) => state.menu.isOpen);
   const darkMode = useDarkMode();
 
   return (
     <motion.div
       className={`${
         darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
-      } ${
-        isOpen ? "" : "pointer-events-none"
       } flex justify-center items-center flex-col space-y-4 text-lg sm:text-xl md:text-2xl lg:text-3xl xl:text-3xl w-screen h-screen z-5 fixed transition-all duration-300 ease-in-out`}
       variants={containerVariants}
       initial="hidden"
-      animate={isOpen ? "visible" : "hidden"}
+      animate="visible"
       exit="exit"
     >
       <div>

--- a/src/Components/Projects/ProjectList.tsx
+++ b/src/Components/Projects/ProjectList.tsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+import { Project } from "../../types";
+
+interface ProjectListProps {
+  data: Project[];
+}
+
+export default function ProjectList({ data }: ProjectListProps) {
+  return (
+    <>
+      {data.map((item: Project) => (
+        <Link to={`${item.id}`}>{item.title}</Link>
+      ))}
+    </>
+  );
+}

--- a/src/Pages/ProjectDetails.tsx
+++ b/src/Pages/ProjectDetails.tsx
@@ -20,7 +20,10 @@ export default function ProjectDetails() {
         <>
           <>{data.title}</>
           <>{data.type}</>
-          <div style={{ backgroundColor: `${data.thumbnailBgColor}` }}>
+          <div
+            className="flex justify-center items-center w-48 aspect-square"
+            style={{ backgroundColor: `${data.thumbnailBgColor}` }}
+          >
             <img src={data.thumbnailLogo} alt={data.id} />
           </div>
           <>{data.description}</>

--- a/src/Pages/ProjectDetails.tsx
+++ b/src/Pages/ProjectDetails.tsx
@@ -1,12 +1,63 @@
 import { useParams } from "react-router-dom";
 import useFetchDocument from "../utils/hooks/useFetchDocument";
+import { Project } from "../types";
 
 export default function ProjectDetails() {
   const { id } = useParams();
-  const { data, error, loading } = useFetchDocument("/projects", `${id}`);
+  const { data, error, loading } = useFetchDocument<Project>(
+    "/projects",
+    `${id}`
+  );
   console.log(data);
   console.log(error);
   console.log(loading);
 
-  return <></>;
+  return (
+    <>
+      {loading && <div>Loading...</div>}
+      {error && <div>Error: {error.message}</div>}
+      {data && (
+        <>
+          <>{data.title}</>
+          <>{data.type}</>
+          <div style={{ backgroundColor: `${data.thumbnailBgColor}` }}>
+            <img src={data.thumbnailLogo} alt={data.id} />
+          </div>
+          <>{data.description}</>
+          <>
+            {data.stacks.map((item) => (
+              <div>{item}</div>
+            ))}
+          </>
+          <div>
+            <div>문서주소</div>
+            {data.docsUrls.map((item) => (
+              <a href={item.url} target="_blank">
+                {item.title}
+              </a>
+            ))}
+          </div>
+
+          <div>
+            <a href={data.deployUrl} target="_blank">
+              배포링크
+            </a>
+          </div>
+
+          <div>
+            <a href={data.gitHubUrl} target="_blank">
+              {" "}
+              깃허브 링크
+            </a>
+          </div>
+
+          <>
+            {data.imgs.map((url, index) => (
+              <img src={url} alt={`${index}`} />
+            ))}
+          </>
+        </>
+      )}
+    </>
+  );
 }

--- a/src/Pages/ProjectDetails.tsx
+++ b/src/Pages/ProjectDetails.tsx
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom";
+import useFetchDocument from "../utils/hooks/useFetchDocument";
+
+export default function ProjectDetails() {
+  const { id } = useParams();
+  const { data, error, loading } = useFetchDocument("/projects", `${id}`);
+  console.log(data);
+  console.log(error);
+  console.log(loading);
+
+  return <></>;
+}

--- a/src/Pages/Projects.tsx
+++ b/src/Pages/Projects.tsx
@@ -1,8 +1,12 @@
 import { Link } from "react-router-dom";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
+import useFetchCollection from "../utils/hooks/useFetchCollection";
+import { Project } from "../types";
+import ProjectList from "../Components/Projects/ProjectList";
 
 export default function Projects() {
   const darkMode = useDarkMode();
+  const { data, loading, error } = useFetchCollection<Project>("/projects");
 
   return (
     <div
@@ -12,6 +16,7 @@ export default function Projects() {
     >
       <section className="w-screen h-screen flex flex-col justify-center items-center">
         this is projects page
+        <ProjectList data={data} />
         <Link
           to="/"
           className={`${

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,22 @@ export interface Skill {
   icon: string;
   description: string;
 }
+
+interface DocUrl {
+  title: string;
+  url: string;
+}
+
+export interface Project {
+  id: string;
+  title: string;
+  thumbnailBgColor: string;
+  thumbnailLogo: string;
+  type: string;
+  imgs: Array<string>;
+  stacks: Array<string>;
+  description: string;
+  docsUrls: DocUrl[];
+  deployUrl: string;
+  gitHubUrl: string;
+}

--- a/src/utils/hooks/useFetchDocument.ts
+++ b/src/utils/hooks/useFetchDocument.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../../firebase/firestore";
+
+const useFetchDocument = <T>(collectionPath: string, docId: string) => {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const documentRef = doc(db, collectionPath, docId);
+        const documentSnapshot = await getDoc(documentRef);
+        if (documentSnapshot.exists()) {
+          setData(documentSnapshot.data() as T);
+        } else {
+          setData(null);
+        }
+      } catch (e) {
+        if (e instanceof Error) {
+          setError(e);
+        } else {
+          setError(new Error("An unknown error occurred."));
+        }
+      }
+      setLoading(false);
+    };
+
+    fetchData();
+  }, [collectionPath, docId]);
+
+  return { data, loading, error };
+};
+
+export default useFetchDocument;


### PR DESCRIPTION
- Projects 페이지에서 프로젝트 데이터 콜렉션을 불러와 ProjectList로 전달 (각 프로젝트 링크에 hover 시 대표 이미지 보여줄것임!)
- ProjectList의 링크 클릭 시 ProjectDetails 페이지로 이동
- ProjectDetailPage에서는 useParams로 페이지 id를 가져와 useFetchDocument로 해당  Id를 가진 문서 데이터를 불러오고 화면에 띄워줌