### PR TITLE
design: 카드리스트 스타일 변경, 카드에 애니메이션 적용

### DIFF
--- a/src/Components/About/SkillCard.tsx
+++ b/src/Components/About/SkillCard.tsx
@@ -1,27 +1,67 @@
 import { Skill } from "../../types";
+import { motion } from "framer-motion";
 
 interface SkillCardProps {
   skill: Skill;
+  isSelected: boolean;
 }
 
-export default function SkillCard({ skill }: SkillCardProps) {
+const containerVariants = {
+  hidden: { x: "-50%", opacity: 0 },
+  show: {
+    x: 0,
+    opacity: 1,
+    transition: {
+      duration: 0.5,
+      type: "spring",
+      damping: 14,
+      stiffness: 100,
+    },
+  },
+  exit: { x: "-160%" },
+};
+
+const imageVariants = {
+  hidden: { y: "-10%", opacity: 0 },
+  show: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      delay: 0.2, // 애니메이션 시작 전 0.4초 대기
+      duration: 0.5,
+      type: "spring",
+      damping: 11,
+      stiffness: 100,
+    },
+  },
+};
+
+export default function SkillCard({ skill, isSelected }: SkillCardProps) {
   return (
-    <li className=" text-gray-700 bg-white flex flex-col max-w-[320px] min-w-[320px] h-[512px] rounded-xl overflow-hidden shadow-xl">
-      <section style={{ background: `${skill.bgColorCode}` }}>
-        <img
+    <motion.li
+      className={`mt-10 last:shadow-xl text-gray-700 bg-white flex flex-col max-w-[320px] min-w-[320px] h-[512px] rounded-xl overflow-hidden ${
+        isSelected && "shadow-xl"
+      }`}
+      variants={containerVariants}
+      initial="hidden"
+      animate={isSelected ? "show" : "exit"}
+    >
+      <section style={{ background: `${skill.bgColorCode}` }} className="h-2/3">
+        <motion.img
           src={skill.imgUrl}
           alt={skill.title}
           className="w-full pointer-events-none"
+          variants={imageVariants}
         />
       </section>
       <section className="p-2 mt-2 h-1/3">
         <section className="pl-2 font-bold">{skill.title}</section>
         <ul className=" list-disc p-3 pl-10 h-32 overflow-y-scroll">
-          {skill.description.map((item) => (
-            <li>{item}</li>
+          {skill.description.map((item, index) => (
+            <li key={index}>{item}</li>
           ))}
         </ul>
       </section>
-    </li>
+    </motion.li>
   );
 }

--- a/src/Components/About/SkillContainer.tsx
+++ b/src/Components/About/SkillContainer.tsx
@@ -3,6 +3,7 @@ import SkillList from "./SkillList";
 import SkillCard from "./SkillCard";
 import { Skill, SkillSet } from "../../types";
 import { AnimatePresence } from "framer-motion";
+import useCacheSkillImages from "../../utils/hooks/useCacheSkillImages";
 
 interface SkillContainerProps {
   data: SkillSet[];
@@ -16,6 +17,8 @@ export default function SkillContainer({ data }: SkillContainerProps) {
       setSelectedSkill(data[0].data[0]);
     }
   }, [data]);
+
+  useCacheSkillImages(data);
 
   return (
     <section className="flex flex-col items-center">

--- a/src/Components/About/SkillContainer.tsx
+++ b/src/Components/About/SkillContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import SkillList from "./SkillList";
 import SkillCard from "./SkillCard";
 import { Skill, SkillSet } from "../../types";
+import { AnimatePresence } from "framer-motion";
 
 interface SkillContainerProps {
   data: SkillSet[];
@@ -17,15 +18,21 @@ export default function SkillContainer({ data }: SkillContainerProps) {
   }, [data]);
 
   return (
-    <section>
+    <section className="flex flex-col items-center">
       <section className="text-5xl w-full mb-10 border-b-2 pb-5">
         Skills
       </section>
-      <section className="flex flex-col md:flex-row">
-        <section className="w-full md:w-1/2 flex justify-center">
-          {selectedSkill && (
-            <SkillCard key={selectedSkill.title} skill={selectedSkill} />
-          )}
+      <section className="w-full xl:w-1/2 flex flex-col md:flex-row">
+        <section className="w-full md:w-1/2 flex justify-center relative">
+          <AnimatePresence>
+            {selectedSkill && (
+              <SkillCard
+                key={selectedSkill.title}
+                skill={selectedSkill}
+                isSelected={true}
+              />
+            )}
+          </AnimatePresence>
         </section>
         <section className="w-full flex justify-center mt-10 md:w-1/2">
           <SkillList

--- a/src/Components/About/SkillList.tsx
+++ b/src/Components/About/SkillList.tsx
@@ -12,7 +12,7 @@ export default function SkillList({
   selectedSkill,
 }: SkillListProps) {
   return (
-    <ul className="max-w-[320px] min-w-[320px] mt-[520px] md:max-w-[350px] md:min-w-[350px] md:mt-0 md:w-full rounded-xl p-3 shadow-2xl">
+    <ul className="max-w-[320px] min-w-[320px] md:max-w-[350px] md:min-w-[350px] md:mt-0 md:w-full rounded-xl p-3 shadow-2xl">
       {data.map((skillSet: SkillSet) => (
         <li key={skillSet.title}>
           <section className="cursor-default m-2 text-lg">

--- a/src/Components/About/SkillList.tsx
+++ b/src/Components/About/SkillList.tsx
@@ -12,7 +12,7 @@ export default function SkillList({
   selectedSkill,
 }: SkillListProps) {
   return (
-    <ul className="w-[320px] md:w-full rounded-md p-3 shadow-2xl">
+    <ul className="max-w-[320px] min-w-[320px] mt-[520px] md:max-w-[350px] md:min-w-[350px] md:mt-0 md:w-full rounded-xl p-3 shadow-2xl">
       {data.map((skillSet: SkillSet) => (
         <li key={skillSet.title}>
           <section className="cursor-default m-2 text-lg">
@@ -25,7 +25,7 @@ export default function SkillList({
                 onClick={() => onItemClick(skill)}
                 className={`mx-1 cursor-pointer p-[1px] text-gray-700 bg-slate-100 px-2 rounded-md md:py-[1px] md:my-[2px] hover:bg-blue-100  ${
                   selectedSkill && selectedSkill.title === skill.title
-                    ? `text-white bg-blue-400 cursor-default hover:text-white hover:bg-blue-400 hover:cursor-default`
+                    ? `text-white bg-blue-300 cursor-default hover:bg-blue-300 hover:cursor-default`
                     : ""
                 }`}
               >

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -17,7 +17,7 @@ export default function Header() {
     <section
       className={`${
         darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
-      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15`}
+      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10`}
     >
       <section className="w-40 flex justify-center items-center">
         <section>로고위치</section>

--- a/src/Components/Header/Nav.tsx
+++ b/src/Components/Header/Nav.tsx
@@ -9,7 +9,7 @@ export default function Nav() {
     <motion.div
       className={`${
         darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
-      } flex justify-center items-center flex-col space-y-4  text-5xl w-screen h-screen z-5 fixed transition-all duration-300 ease-in-out`}
+      } flex justify-center items-center flex-col space-y-4  text-5xl w-screen h-screen z-10 fixed transition-all duration-300 ease-in-out`}
       variants={containerVariants}
       initial="hidden"
       animate="visible"

--- a/src/utils/hooks/useCacheSkillImages.ts
+++ b/src/utils/hooks/useCacheSkillImages.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { SkillSet } from "../../types";
+
+const cacheImage = (url: string) => {
+  const img = new Image();
+  img.src = url;
+};
+
+const useCacheSkillImages = (data: SkillSet[]) => {
+  useEffect(() => {
+    const imageUrls = data.flatMap((skillSet) =>
+      skillSet.data.map((skill) => skill.imgUrl)
+    );
+    imageUrls.forEach(cacheImage);
+  }, [data]);
+};
+
+export default useCacheSkillImages;


### PR DESCRIPTION
1. 스킬카드 컴포넌트에 애니메이션을 적용한다.
2. 스킬카드의 렌더링 로직을 변경한다. (selectedSkill 업데이트에 따라 prop만 변경하기 => 모든 SkillCard를 렌더링하고 애니메이션으로 뽑아오기 => AnimationPresence로 감싼 후 SkillCard에 key 프롭을 넘겨주어 selectedSkill이 바뀌면 SkillCard가 언마운트된 후 새 SkillCard가 마운트됨
3. About 페이지 내 스킬 로고 이미지 캐싱 로직 구현
