### PR TITLE
[design] About 페이지 스타일 조정

### DIFF
--- a/src/Components/About/Contacts/ContactsContainer.tsx
+++ b/src/Components/About/Contacts/ContactsContainer.tsx
@@ -1,0 +1,9 @@
+export default function ContactContainer() {
+  return (
+    <section className="flex flex-col items-center">
+      <section className="text-5xl w-full mb-10 border-b-2 pb-5">
+        Contacts
+      </section>
+    </section>
+  );
+}

--- a/src/Components/About/Skills/MobileSkillList.tsx
+++ b/src/Components/About/Skills/MobileSkillList.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { Skill, SkillListProps, SkillSet } from "../../../types";
+
+export default function MobileSkillList({
+  data,
+  onItemClick,
+  selectedSkill,
+}: SkillListProps) {
+  const [selectedCategory, setSelectedCategory] = useState<SkillSet | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (data.length > 0 && data[0].data.length > 0) {
+      setSelectedCategory(data[0]);
+    }
+  }, [data]);
+
+  const handleCategoryClick = (skillSet: SkillSet) => {
+    setSelectedCategory(skillSet);
+  };
+
+  return (
+    <section className=" sm:hidden 2xl:block 5xl:hidden">
+      <ul>
+        {data.map((skillSet: SkillSet) => (
+          <li
+            onClick={() => {
+              handleCategoryClick(skillSet);
+            }}
+            className={`${
+              selectedCategory &&
+              selectedCategory.title === skillSet.title &&
+              "text-white bg-blue-300 cursor-default"
+            }`}
+          >
+            {skillSet.title}
+          </li>
+        ))}
+      </ul>
+      <ul className="flex">
+        {selectedCategory?.data.map((skill: Skill) => (
+          <li
+            onClick={() => {
+              onItemClick(skill);
+            }}
+            className={`${
+              selectedSkill &&
+              selectedSkill.title === skill.title &&
+              "text-white bg-blue-300 cursor-default"
+            }`}
+          >
+            {skill.title}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/Components/About/Skills/SkillCard.tsx
+++ b/src/Components/About/Skills/SkillCard.tsx
@@ -1,4 +1,4 @@
-import { Skill } from "../../types";
+import { Skill } from "../../../types";
 import { motion } from "framer-motion";
 
 interface SkillCardProps {
@@ -26,7 +26,7 @@ export default function SkillCard({ skill, isSelected }: SkillCardProps) {
       </section>
       <section className="p-2 mt-2 h-1/3">
         <section className="pl-2 font-bold">{skill.title}</section>
-        <ul className=" list-disc p-3 pl-10 h-32 overflow-y-scroll">
+        <ul className=" list-disc p-3 pl-10 h-32 overflow-y-auto">
           {skill.description.map((item, index) => (
             <li key={index}>{item}</li>
           ))}

--- a/src/Components/About/Skills/SkillContainer.tsx
+++ b/src/Components/About/Skills/SkillContainer.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import SkillList from "./SkillList";
 import SkillCard from "./SkillCard";
-import { Skill, SkillSet } from "../../types";
+import { Skill, SkillSet } from "../../../types";
 import { AnimatePresence } from "framer-motion";
-import useCacheSkillImages from "../../utils/hooks/useCacheSkillImages";
+import useCacheSkillImages from "../../../utils/hooks/useCacheSkillImages";
+import MobileSkillList from "./MobileSkillList";
 
 interface SkillContainerProps {
   data: SkillSet[];
@@ -25,8 +26,13 @@ export default function SkillContainer({ data }: SkillContainerProps) {
       <section className="text-5xl w-full mb-10 border-b-2 pb-5">
         Skills
       </section>
-      <section className="w-full xl:w-1/2 flex flex-col md:flex-row">
-        <section className="w-full md:w-1/2 flex justify-center relative">
+      <section className="w-full flex flex-col sm:flex-row 2xl:flex-col 5xl:flex-row">
+        <MobileSkillList
+          data={data}
+          onItemClick={(skill: Skill) => setSelectedSkill(skill)}
+          selectedSkill={selectedSkill}
+        />
+        <section className="w-full flex justify-center">
           <AnimatePresence>
             {selectedSkill && (
               <SkillCard
@@ -37,7 +43,7 @@ export default function SkillContainer({ data }: SkillContainerProps) {
             )}
           </AnimatePresence>
         </section>
-        <section className="w-full flex justify-center mt-10 md:w-1/2">
+        <section className="w-full flex justify-center mt-10">
           <SkillList
             data={data}
             onItemClick={(skill: Skill) => setSelectedSkill(skill)}

--- a/src/Components/About/Skills/SkillList.tsx
+++ b/src/Components/About/Skills/SkillList.tsx
@@ -1,10 +1,4 @@
-import { Skill, SkillSet } from "../../types";
-
-interface SkillListProps {
-  data: SkillSet[];
-  onItemClick: (skill: Skill) => void;
-  selectedSkill: Skill | null;
-}
+import { Skill, SkillSet, SkillListProps } from "../../../types";
 
 export default function SkillList({
   data,
@@ -12,18 +6,18 @@ export default function SkillList({
   selectedSkill,
 }: SkillListProps) {
   return (
-    <ul className="max-w-[320px] min-w-[320px] md:max-w-[350px] md:min-w-[350px] md:mt-0 md:w-full rounded-xl p-3 shadow-2xl">
+    <ul className=" hidden sm:block 2xl:hidden 5xl:block md:mt-0 w-[320px] rounded-xl p-3 shadow-2xl 5xl:w-full">
       {data.map((skillSet: SkillSet) => (
         <li key={skillSet.title}>
           <section className="cursor-default m-2 text-lg">
             {skillSet.title}
           </section>
-          <ul className="flex flex-row md:flex-col flex-wrap">
+          <ul className="flex flex-col">
             {skillSet.data.map((skill: Skill) => (
               <li
                 key={skill.title}
                 onClick={() => onItemClick(skill)}
-                className={`mx-1 cursor-pointer p-[1px] text-gray-700 bg-slate-100 px-2 rounded-md md:py-[1px] md:my-[2px] hover:bg-blue-100  ${
+                className={`mx-1 cursor-pointer p-[1px] text-gray-700 bg-slate-100 px-2 rounded-md py-[1px] my-[2px] hover:bg-blue-100  ${
                   selectedSkill && selectedSkill.title === skill.title
                     ? `text-white bg-blue-300 cursor-default hover:bg-blue-300 hover:cursor-default`
                     : ""

--- a/src/Pages/About.tsx
+++ b/src/Pages/About.tsx
@@ -3,7 +3,8 @@ import useFetchDocument from "../utils/hooks/useFetchDocument";
 import { Profile, SkillSet } from "../types";
 import ProfileBox from "../Components/About/ProfileBox";
 import useFetchCollection from "../utils/hooks/useFetchCollection";
-import SkillContainer from "../Components/About/SkillContainer";
+import SkillContainer from "../Components/About/Skills/SkillContainer";
+import ContactContainer from "../Components/About/Contacts/ContactsContainer";
 
 export default function About() {
   const darkMode = useDarkMode();
@@ -26,8 +27,8 @@ export default function About() {
     >
       <section>
         <section className="mt-16">
-          <main className="flex flex-col-reverse md:flex-row md:justify-between w-full">
-            <section className="flex flex-col w-full p-10  ml-0 items-center md:ml-32 md:w-2/3">
+          <main className="flex flex-col-reverse xl:flex-row md:justify-between w-full">
+            <section className="flex flex-col w-full p-10  ml-0 items-center lg:ml-32 lg:w-2/3 xl:w-3/5 2xl:ml-96">
               <section>
                 {profileLoading && <div>Loading profile data...</div>}
                 {profileError && (
@@ -39,19 +40,26 @@ export default function About() {
                   <ProfileBox description={profileData.description} />
                 )}
               </section>
-              <section className="mt-16 w-full">
-                {skillsLoading && <div>Loading skill data...</div>}
-                {skillsError && (
-                  <div>Failed to fetch skill data : {skillsError.message}</div>
-                )}
-                {skillsData && <SkillContainer data={skillsData} />}
+              <section className="w-full flex flex-col 2xl:flex-row">
+                <section className="mt-16 w-full 2xl:w-1/2">
+                  {skillsLoading && <div>Loading skill data...</div>}
+                  {skillsError && (
+                    <div>
+                      Failed to fetch skill data : {skillsError.message}
+                    </div>
+                  )}
+                  {skillsData && <SkillContainer data={skillsData} />}
+                </section>
+                <section className="mt-16 w-full 2xl:w-1/2 2xl:ml-3">
+                  <ContactContainer />
+                </section>
               </section>
             </section>
             {profileData && (
               <img
                 src={profileData.imgUrl}
                 alt={profileData.imgUrl}
-                className="rounded-xl min-w-[250px] m-6 md:w-1/5 md:m-0 md:h-auto md:rounded-none md:rounded-bl-[20%]"
+                className="rounded-xl object-cover min-w-[250px] m-6 h-[60vh] xl:w-1/5 xl:m-0 xl:h-2/3 xl:rounded-none xl:rounded-bl-[20%]"
               />
             )}
           </main>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,12 @@ export interface SkillSet {
   data: Skill[];
 }
 
+export interface SkillListProps {
+  data: SkillSet[];
+  onItemClick: (skill: Skill) => void;
+  selectedSkill: Skill | null;
+}
+
 interface DocUrl {
   title: string;
   url: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,14 @@
 export default {
   content: ["./src/**/*.{html,js,tsx,jsx,ts}"],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        "3xl": "1530px",
+        "4xl": "1850px",
+        "5xl": "2000px",
+        "6xl": "2300px",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
1. Contacts 페이지를 삭제하고 About에 병합하기 위해 ContactsContainer 컴포넌트 생성
2. About 페이지 내에서 특정 화면 크기에 도달할 시 Skills와 Contacts를 같은 행에 표시하도록 처리
3. Skills 컨테이너의 스킬카드와 스킬리스트가 화면 크기에 따라 다르게 표시되도록 조율
4. Skills 컨테이너의 너비가 일정 길이 이하일 때, MobileSkillList를 표시하도록 로직 추가
5. About페이지 내 프로필사진 반응형 처리 수정
6. About 페이지 내 표시할 정보가 늘어남에 따라 Components/About/ 디렉토리 내에 각 로직 별 서브디렉토리 생성