### PR TITLE
feat: 프로젝트 리스트 세부 구현 시작

### DIFF
--- a/src/Components/About/Skills/SkillContainer.tsx
+++ b/src/Components/About/Skills/SkillContainer.tsx
@@ -3,7 +3,6 @@ import SkillList from "./SkillList";
 import SkillCard from "./SkillCard";
 import { Skill, SkillSet } from "../../../types";
 import { AnimatePresence } from "framer-motion";
-import useCacheSkillImages from "../../../utils/hooks/useCacheSkillImages";
 import MobileSkillList from "./MobileSkillList";
 
 interface SkillContainerProps {
@@ -18,8 +17,6 @@ export default function SkillContainer({ data }: SkillContainerProps) {
       setSelectedSkill(data[0].data[0]);
     }
   }, [data]);
-
-  useCacheSkillImages(data);
 
   return (
     <section className="flex flex-col items-center">

--- a/src/Components/ProjectDetails/ProjectImageList.tsx
+++ b/src/Components/ProjectDetails/ProjectImageList.tsx
@@ -1,0 +1,15 @@
+interface ProjectImageListProps {
+  imgs: string[];
+}
+
+export default function ProjectImageList({ imgs }: ProjectImageListProps) {
+  return (
+    <ul>
+      {imgs.map((item: string, index) => (
+        <li key={index}>
+          <img src={item} alt={String(index)} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/Components/Projects/ProjectList.tsx
+++ b/src/Components/Projects/ProjectList.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Project } from "../../types";
 import { useState } from "react";
+import { useCacheProjectThumbnails } from "../../utils/hooks/useCacheSkillImages";
 
 interface ProjectListProps {
   data: Project[];
@@ -8,6 +9,7 @@ interface ProjectListProps {
 
 export default function ProjectList({ data }: ProjectListProps) {
   const [hoveredItem, setHoveredItem] = useState<Project | null>(null);
+  useCacheProjectThumbnails(data);
 
   return (
     <main>

--- a/src/Components/Projects/ProjectList.tsx
+++ b/src/Components/Projects/ProjectList.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import { Project } from "../../types";
 import { useState } from "react";
-import { useCacheProjectThumbnails } from "../../utils/hooks/useCacheSkillImages";
 
 interface ProjectListProps {
   data: Project[];
@@ -9,7 +8,6 @@ interface ProjectListProps {
 
 export default function ProjectList({ data }: ProjectListProps) {
   const [hoveredItem, setHoveredItem] = useState<Project | null>(null);
-  useCacheProjectThumbnails(data);
 
   return (
     <main>

--- a/src/Components/Projects/ProjectList.tsx
+++ b/src/Components/Projects/ProjectList.tsx
@@ -1,16 +1,41 @@
 import { Link } from "react-router-dom";
 import { Project } from "../../types";
+import { useState } from "react";
 
 interface ProjectListProps {
   data: Project[];
 }
 
 export default function ProjectList({ data }: ProjectListProps) {
+  const [hoveredItem, setHoveredItem] = useState<Project | null>(null);
+
   return (
-    <>
-      {data.map((item: Project) => (
-        <Link to={`${item.id}`}>{item.title}</Link>
-      ))}
-    </>
+    <main>
+      <section className="hidden sm:block fixed bottom-0 left-0">
+        {hoveredItem && (
+          <section style={{ background: `${hoveredItem.thumbnailBgColor}` }}>
+            <img
+              key={hoveredItem.title}
+              src={hoveredItem.thumbnailLogo}
+              alt={hoveredItem.title}
+            />
+          </section>
+        )}
+      </section>
+      <ul className="flex flex-col">
+        {data.map((item: Project) => (
+          <Link
+            to={`${item.id}`}
+            onMouseOver={() => {
+              setHoveredItem(item);
+              console.log("asdf");
+            }}
+            onMouseOut={() => setHoveredItem(null)}
+          >
+            {item.title}
+          </Link>
+        ))}
+      </ul>
+    </main>
   );
 }

--- a/src/Pages/About.tsx
+++ b/src/Pages/About.tsx
@@ -5,6 +5,7 @@ import ProfileBox from "../Components/About/ProfileBox";
 import useFetchCollection from "../utils/hooks/useFetchCollection";
 import SkillContainer from "../Components/About/Skills/SkillContainer";
 import ContactContainer from "../Components/About/Contacts/ContactsContainer";
+import { useCacheSkillImages } from "../utils/hooks/useCacheSkillImages";
 
 export default function About() {
   const darkMode = useDarkMode();
@@ -23,6 +24,7 @@ export default function About() {
     loading: contactsLoading,
     error: contactsError,
   } = useFetchDocument<ContactSet>("/about", "contacts");
+  useCacheSkillImages(skillsData);
 
   return (
     <div

--- a/src/Pages/ProjectDetails.tsx
+++ b/src/Pages/ProjectDetails.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import useFetchDocument from "../utils/hooks/useFetchDocument";
 import { Project } from "../types";
+import { useCacheProjectImages } from "../utils/hooks/useCacheSkillImages";
 
 export default function ProjectDetails() {
   const { id } = useParams();
@@ -8,9 +9,7 @@ export default function ProjectDetails() {
     "/projects",
     `${id}`
   );
-  console.log(data);
-  console.log(error);
-  console.log(loading);
+  useCacheProjectImages(data);
 
   return (
     <>
@@ -49,7 +48,6 @@ export default function ProjectDetails() {
 
           <div>
             <a href={data.gitHubUrl} target="_blank">
-              {" "}
               깃허브 링크
             </a>
           </div>

--- a/src/Pages/Projects.tsx
+++ b/src/Pages/Projects.tsx
@@ -3,10 +3,12 @@ import { useDarkMode } from "../utils/hooks/useDarkMode";
 import useFetchCollection from "../utils/hooks/useFetchCollection";
 import { Project } from "../types";
 import ProjectList from "../Components/Projects/ProjectList";
+import { useCacheProjectThumbnails } from "../utils/hooks/useCacheSkillImages";
 
 export default function Projects() {
   const darkMode = useDarkMode();
   const { data, loading, error } = useFetchCollection<Project>("/projects");
+  useCacheProjectThumbnails(data);
 
   return (
     <div

--- a/src/Pages/Projects.tsx
+++ b/src/Pages/Projects.tsx
@@ -15,7 +15,6 @@ export default function Projects() {
       } transition-all duration-300 ease-in-out`}
     >
       <section className="w-screen h-screen flex flex-col justify-center items-center">
-        this is projects page
         {loading && <div>Loading...</div>}
         {error && <div>Error: {error.message}</div>}
         {data && <ProjectList data={data} />}

--- a/src/utils/hooks/useCacheSkillImages.ts
+++ b/src/utils/hooks/useCacheSkillImages.ts
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
-import { SkillSet } from "../../types";
+import { Project, SkillSet } from "../../types";
 
 const cacheImage = (url: string) => {
   const img = new Image();
   img.src = url;
 };
 
-const useCacheSkillImages = (data: SkillSet[]) => {
+export const useCacheSkillImages = (data: SkillSet[]) => {
   useEffect(() => {
     const imageUrls = data.flatMap((skillSet) =>
       skillSet.data.map((skill) => skill.imgUrl)
@@ -15,4 +15,15 @@ const useCacheSkillImages = (data: SkillSet[]) => {
   }, [data]);
 };
 
-export default useCacheSkillImages;
+export const useCacheProjectThumbnails = (data: Project[]) => {
+  useEffect(() => {
+    const imageUrls = data.flatMap((project) => project.thumbnailLogo);
+    imageUrls.forEach(cacheImage);
+  }, [data]);
+};
+
+export const useCacheProjectImages = (data: Project) => {
+  useEffect(() => {
+    data.imgs.forEach(cacheImage);
+  });
+};

--- a/src/utils/hooks/useCacheSkillImages.ts
+++ b/src/utils/hooks/useCacheSkillImages.ts
@@ -15,15 +15,17 @@ export const useCacheSkillImages = (data: SkillSet[]) => {
   }, [data]);
 };
 
-export const useCacheProjectThumbnails = (data: Project[]) => {
+export const useCacheProjectThumbnails = (data: Project[] | null) => {
   useEffect(() => {
-    const imageUrls = data.flatMap((project) => project.thumbnailLogo);
-    imageUrls.forEach(cacheImage);
+    if (data) {
+      const imageUrls = data.flatMap((project) => project.thumbnailLogo);
+      imageUrls.forEach(cacheImage);
+    }
   }, [data]);
 };
 
-export const useCacheProjectImages = (data: Project) => {
+export const useCacheProjectImages = (data: Project | null) => {
   useEffect(() => {
-    data.imgs.forEach(cacheImage);
-  });
+    data && data.imgs.forEach(cacheImage);
+  }, [data]);
 };


### PR DESCRIPTION
1. 프로젝트 리스트 아이템 호버 시 프로젝트 로고 이미지 표시
2. 프로젝트, 프로젝트썸네일, 스킬카드 이미지 캐싱 로직 구현 및 정비