### PR TITLE
design : Contacts 섹션 아이템 스타일 적용

### DIFF
--- a/src/Components/About/Contacts/ContactsContainer.tsx
+++ b/src/Components/About/Contacts/ContactsContainer.tsx
@@ -7,12 +7,12 @@ interface ContactContainerProps {
 
 export default function ContactContainer({ data }: ContactContainerProps) {
   return (
-    <section className="flex flex-col items-center">
-      <section className="text-5xl w-full mb-10 border-b-2 pb-5">
+    <section className="flex flex-col items-center mb-80 pl-2">
+      <section className="text-5xl w-full mb-10 border-b-2 pb-5 cursor-default">
         Contacts
       </section>
-      <section>
-        <ul>
+      <section className="w-full px-6">
+        <ul className="flex flex-wrap justify-between">
           {data.data.map((contact: Contact | ContactMisc) => (
             <ContactsItem key={contact.title} contact={contact} />
           ))}

--- a/src/Components/About/Contacts/ContactsItem.tsx
+++ b/src/Components/About/Contacts/ContactsItem.tsx
@@ -14,54 +14,82 @@ const CONTACT_TYPES = {
   URL: "url",
 };
 
+interface ListItemProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function ListItem({ title, children }: ListItemProps) {
+  return (
+    <li className="flex items-center mx-2">
+      <section className="mr-2 text-3xl py-4 pr-2 border-r-2 cursor-default min-w-[98px]">
+        {title}
+      </section>
+      <section className="text-xl min-w-[206px]">{children}</section>
+    </li>
+  );
+}
+
 export default function ContactsItem({ contact }: ContactsItemProps) {
   if (isContact(contact)) {
+    let content;
     switch (contact.type) {
       case CONTACT_TYPES.MAIL:
-        return (
-          <li>
-            <section>{contact.title}</section>
-            <a href={`mailto:${contact.data}`}>{contact.subtitle}</a>
-          </li>
+        content = (
+          <a
+            className="hover:text-blue-400 transition-all ease-in-out"
+            href={`mailto:${contact.data}`}
+          >
+            {contact.subtitle}
+          </a>
         );
+        break;
       case CONTACT_TYPES.TEL:
-        return (
-          <li>
-            <section>{contact.title}</section>
-            <a href={`tel:${contact.data}`}>{contact.subtitle}</a>
-          </li>
+        content = (
+          <a
+            className="hover:text-blue-400 transition-all ease-in-out"
+            href={`tel:${contact.data}`}
+          >
+            {contact.subtitle}
+          </a>
         );
+        break;
       case CONTACT_TYPES.URL:
-        return (
-          <li>
-            <section>{contact.title}</section>
-            <a href={contact.data} target="_blank" rel="noopener noreferrer">
-              {contact.subtitle}
-            </a>
-          </li>
+        content = (
+          <a
+            className="hover:text-blue-400 transition-all ease-in-out"
+            href={contact.data}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {contact.subtitle}
+          </a>
         );
-
+        break;
       default:
-        return (
-          <li>
-            <section>{contact.title}</section>
-            <section>{contact.subtitle}</section>
-          </li>
+        content = (
+          <section className="hover:text-blue-400 transition-all ease-in-out">
+            {contact.subtitle}
+          </section>
         );
     }
+    return <ListItem title={contact.title}>{content}</ListItem>;
   }
+
   return (
-    <li>
-      <section>{contact.title}</section>
-      <ul>
+    <ListItem title={contact.title}>
+      <ul className="flex">
         {contact.data.map((item: ContactMiscData) => (
-          <li key={item.title}>
+          <li
+            key={item.title}
+            className="w-8 h-8 mx-[2px] hover:-translate-y-1 ease-in-out transition-all active:translate-y-0"
+          >
             <a href={`${item.url}`} target="_blank" rel="noopener noreferrer">
               <img src={item.img} alt={item.title} />
             </a>
           </li>
         ))}
       </ul>
-    </li>
+    </ListItem>
   );
 }

--- a/src/Components/About/ProfileBox.tsx
+++ b/src/Components/About/ProfileBox.tsx
@@ -5,8 +5,10 @@ interface ProfileBoxProps {
 export default function ProfileBox({ description }: ProfileBoxProps) {
   return (
     <section className="flex flex-col">
-      <section className="text-5xl w-full mb-10 border-b-2 pb-5">About</section>
-      <section className="w-full md:w-5/6">{description}</section>
+      <section className="text-5xl w-full mb-10 border-b-2 pb-5 cursor-default">
+        About
+      </section>
+      <section className="w-full md:w-5/6 px-4">{description}</section>
     </section>
   );
 }

--- a/src/Components/About/Skills/SkillContainer.tsx
+++ b/src/Components/About/Skills/SkillContainer.tsx
@@ -20,7 +20,7 @@ export default function SkillContainer({ data }: SkillContainerProps) {
 
   return (
     <section className="flex flex-col items-center">
-      <section className="text-5xl w-full mb-10 border-b-2 pb-5">
+      <section className="text-5xl w-full mb-10 border-b-2 pb-5 cursor-default">
         Skills
       </section>
       <section className="w-full flex flex-col sm:flex-row 2xl:flex-col 5xl:flex-row">
@@ -29,7 +29,7 @@ export default function SkillContainer({ data }: SkillContainerProps) {
           onItemClick={(skill: Skill) => setSelectedSkill(skill)}
           selectedSkill={selectedSkill}
         />
-        <section className="w-full flex justify-center">
+        <section className="w-full min-w-[325px] flex justify-center">
           <AnimatePresence>
             {selectedSkill && (
               <SkillCard

--- a/src/Components/About/Skills/SkillList.tsx
+++ b/src/Components/About/Skills/SkillList.tsx
@@ -17,9 +17,9 @@ export default function SkillList({
               <li
                 key={skill.title}
                 onClick={() => onItemClick(skill)}
-                className={`mx-1 cursor-pointer p-[1px] text-gray-700 bg-slate-100 px-2 rounded-md py-[1px] my-[2px] hover:bg-blue-100  ${
+                className={`mx-1 cursor-pointer p-[1px] text-gray-700 bg-slate-100 px-2 rounded-md py-[1px] my-[2px] hover:bg-blue-100 active:bg-blue-200 transition-all ease-in-out ${
                   selectedSkill && selectedSkill.title === skill.title
-                    ? `text-white bg-blue-300 cursor-default hover:bg-blue-300 hover:cursor-default`
+                    ? `text-white bg-blue-400 cursor-default hover:bg-blue-400 active:bg-blue-400 hover:cursor-default`
                     : ""
                 }`}
               >

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -17,7 +17,7 @@ export default function Header() {
     <section
       className={`${
         darkMode ? "text-white" : "text-gray-700"
-      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10 mix-blend-exclusion`}
+      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10 mix-blend-difference`}
     >
       <section className="w-40 flex justify-center items-center">
         <section>로고위치</section>

--- a/src/Pages/About.tsx
+++ b/src/Pages/About.tsx
@@ -30,10 +30,10 @@ export default function About() {
     <div
       className={`${
         darkMode ? "text-white bg-slate-500" : "text-gray-700"
-      } transition-all duration-300 ease-in-out`}
+      } transition-all duration-300 ease-in-out pt-10 xl:pt-0 min-h-screen`}
     >
       <section>
-        <section className="mt-16">
+        <section>
           <main className="flex flex-col-reverse xl:flex-row md:justify-between w-full">
             <section className="flex flex-col w-full p-10  ml-0 items-center lg:ml-32 lg:w-2/3 xl:w-3/5 2xl:ml-96">
               <section>
@@ -57,7 +57,7 @@ export default function About() {
                   )}
                   {skillsData && <SkillContainer data={skillsData} />}
                 </section>
-                <section className="mt-16 w-full 2xl:w-1/2 2xl:ml-3">
+                <section className="mt-16 w-full 2xl:w-1/2">
                   {contactsLoading && <div>Loading contact data...</div>}
                   {contactsError && (
                     <div>
@@ -72,7 +72,7 @@ export default function About() {
               <img
                 src={profileData.imgUrl}
                 alt={profileData.imgUrl}
-                className="rounded-xl object-cover min-w-[250px] m-6 h-[60vh] xl:w-1/5 xl:m-0 xl:h-2/3 xl:rounded-none xl:rounded-bl-[20%]"
+                className="rounded-xl object-cover min-w-[250px] m-6 h-[60vh] xl:w-2/5 2xl:w-1/5 xl:m-0 xl:h-2/3 xl:rounded-none xl:rounded-bl-[20%]"
               />
             )}
           </main>


### PR DESCRIPTION
1. Contact 섹션의 각 아이템들에 스타일을 적용한다.
2. 프로필 이미지와 헤더의 스타일을 수정 (프로필 이미지 : 특정 화면크기일 때의 이미지 크기를 변경) (헤더 : 믹스블렌드 모드를 exclusion에서 difference로 변경)
3. 헤더의 수정사항에 따라 About 페이지의 mt속성을 조정한다. (작은 화면일 때는 mt를 주는게 적절하고, 큰 화면에서는 mt를 없애서 이미지와 겹치도록 함)
4. Contacts 섹션이 자연스럽게 보이도록 적절한 크기의 마진바텀을 준다