### PR TITLE
design: 로고 커스터마이징 적용

### DIFF
--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -4,8 +4,13 @@ import { useSelector, useDispatch } from "react-redux";
 import { toggleMenu } from "../../redux/slices/menuSlice";
 import { RootState } from "../../redux/store";
 import NavButton from "./NavButton";
+import Logo from "../Main/Logo";
+import { useLocation } from "react-router-dom";
 
 export default function Header() {
+  const location = useLocation();
+  const path = location.pathname;
+  const isSpecialPage = path === "/about" || /^\/projects\/\w+/.test(path);
   const dispatch = useDispatch();
   const darkMode = useDarkMode();
   const isOpen = useSelector((state: RootState) => state.menu.isOpen);
@@ -17,10 +22,14 @@ export default function Header() {
     <section
       className={`${
         darkMode ? "text-white" : "text-gray-700"
-      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10 mix-blend-difference`}
+      } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10 ${
+        isSpecialPage && "mix-blend-difference"
+      }`}
     >
       <section className="w-40 flex justify-center items-center">
-        <section>로고위치</section>
+        <section className="flex items-center">
+          <Logo width="30" height="30" />
+        </section>
       </section>
       <section className="flex w-32 justify-around items-center p-5">
         <DarkModeButton />

--- a/src/Components/Main/Logo.tsx
+++ b/src/Components/Main/Logo.tsx
@@ -1,42 +1,105 @@
 import { motion } from "framer-motion";
+import AnimatedText from "../../utils/AnimatedText";
 
-export default function Logo() {
+interface LogoProps {
+  width: string;
+  height: string;
+  strokeWidth?: string;
+  animated?: boolean;
+  vertical?: boolean;
+}
+
+export default function Logo({
+  width,
+  height,
+  animated = false,
+  strokeWidth = "300",
+  vertical = false,
+}: LogoProps) {
+  const directionStyle = `${
+    vertical ? "flex flex-col items-center" : "flex flex-row items-center"
+  }`;
+  if (animated) {
+    return (
+      <section className={`${directionStyle}`}>
+        <svg
+          width={width}
+          height={height}
+          viewBox="0 0 2081 2946"
+          fill="none"
+          stroke="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            d="M150 1374V1905.49C150 2397.31 548.69 2796 1040.5 2796C1532.31 2796 1931 2397.31 1931 1905.49V887"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            initial={{ strokeDasharray: "180% 250%", strokeDashoffset: "260%" }}
+            animate={{ strokeDashoffset: "0%" }}
+            transition={{ duration: 1, delay: 0 }}
+          />
+          <motion.path
+            d="M599 507.747V1913.91C599 2158.07 796.89 2356 1041 2356C1285.11 2356 1483 2158.07 1483 1913.91V354"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            initial={{ strokeDasharray: "180% 250%", strokeDashoffset: "190%" }}
+            animate={{ strokeDashoffset: "0%" }}
+            transition={{ duration: 1, delay: 0.35 }}
+          />
+          <motion.path
+            d="M1041 150L1041 1920"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            initial={{ strokeDasharray: "100%", strokeDashoffset: "100%" }}
+            animate={{ strokeDashoffset: "0%" }}
+            transition={{ duration: 1, delay: 0.7 }}
+          />
+        </svg>
+        <section
+          className={`cursor-default ${vertical ? "text-3xl mt-3" : ""}`}
+        >
+          <AnimatedText text="thewronghand" />
+        </section>
+      </section>
+    );
+  }
   return (
-    <svg
-      width="125"
-      height="175"
-      viewBox="0 0 2081 2946"
-      fill="none"
-      stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <motion.path
-        d="M150 1374V1905.49C150 2397.31 548.69 2796 1040.5 2796C1532.31 2796 1931 2397.31 1931 1905.49V887"
+    <section className={`${directionStyle}`}>
+      <svg
+        width={width}
+        height={height}
+        viewBox="0 0 2081 2946"
+        fill="none"
         stroke="currentColor"
-        strokeWidth="260"
-        strokeLinecap="round"
-        initial={{ strokeDasharray: "180% 250%", strokeDashoffset: "260%" }}
-        animate={{ strokeDashoffset: "0%" }}
-        transition={{ duration: 1, delay: 0 }}
-      />
-      <motion.path
-        d="M599 507.747V1913.91C599 2158.07 796.89 2356 1041 2356C1285.11 2356 1483 2158.07 1483 1913.91V354"
-        stroke="currentColor"
-        strokeWidth="260"
-        strokeLinecap="round"
-        initial={{ strokeDasharray: "180% 250%", strokeDashoffset: "190%" }}
-        animate={{ strokeDashoffset: "0%" }}
-        transition={{ duration: 1, delay: 0.35 }}
-      />
-      <motion.path
-        d="M1041 150L1041 1920"
-        stroke="currentColor"
-        strokeWidth="260"
-        strokeLinecap="round"
-        initial={{ strokeDasharray: "100%", strokeDashoffset: "100%" }}
-        animate={{ strokeDashoffset: "0%" }}
-        transition={{ duration: 1, delay: 0.7 }}
-      />
-    </svg>
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M150 1374V1905.49C150 2397.31 548.69 2796 1040.5 2796C1532.31 2796 1931 2397.31 1931 1905.49V887"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+        <path
+          d="M599 507.747V1913.91C599 2158.07 796.89 2356 1041 2356C1285.11 2356 1483 2158.07 1483 1913.91V354"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+        <path
+          d="M1041 150L1041 1920"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+      </svg>
+      <section
+        className={`cursor-default ${vertical ? "text-3xl mt-3" : "ml-1"}`}
+      >
+        thewronghand
+      </section>
+    </section>
   );
 }

--- a/src/Pages/Main.tsx
+++ b/src/Pages/Main.tsx
@@ -8,14 +8,15 @@ export default function Main() {
     <div
       className={`${
         darkMode ? "text-white bg-slate-500" : "text-gray-700"
-      } w-screen h-screen flex flex-col sm:flex-row justify-center items-center transition-all duration-300 ease-in-out`}
+      } w-screen h-screen flex flex-col justify-center items-center transition-all duration-300 ease-in-out`}
     >
-      <Logo />
-      <div className="flex justify-center items-center w-full h-1/5 sm:w-2/5 text-xl sm:text-2xl md:text-3xl lg:4xl xl:text-4xl text-center">
-        프론트엔드 개발자 이의현
-        <br />
-        그른손thewronghand의 포트폴리오입니다.
-      </div>
+      <Logo
+        width="125"
+        height="175"
+        strokeWidth="270"
+        animated={true}
+        vertical={true}
+      />
     </div>
   );
 }

--- a/src/utils/AnimatedText.tsx
+++ b/src/utils/AnimatedText.tsx
@@ -1,0 +1,54 @@
+import { motion } from "framer-motion";
+
+interface AnimatedTextProps {
+  text: string;
+}
+
+export default function AnimatedText({ text }: AnimatedTextProps) {
+  const characters = Array.from(text);
+
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: (i = 1) => ({
+      opacity: 1,
+      transition: { staggerChildren: 0.05, delayChildren: 0.1 * i + 1 },
+    }),
+  };
+
+  const childVariants = {
+    visible: {
+      opacity: 1,
+      y: 0,
+      x: 0,
+      transition: {
+        type: "spring",
+        damping: 12,
+        stiffness: 100,
+      },
+    },
+    hidden: {
+      opacity: 0,
+      y: 20,
+      transition: {
+        type: "spring",
+        damping: 12,
+        stiffness: 100,
+      },
+    },
+  };
+
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+      className="overflow-hidden flex"
+    >
+      {characters.map((char: string, index) => (
+        <motion.span variants={childVariants} className="" key={index}>
+          {char}
+        </motion.span>
+      ))}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
1. Main에 쓰는 로고와 Header에 쓰는 로고를 동일한 컴포넌트로 하고 싶음 (따로 만들기 싫음) 
2. 로고에 animate 프롭에 따라 애니메이션에 대한 분기처리를 적용하여 애니메이션 여부를 설정할 수 있게 함
3. vertical 프롭으로 텍스트(thewronghand)를 옆에 둘 것이냐 아래 둘 것이냐 정할 수 있게 함
4. AnimatedText 컴포넌트 구현
5. animate시 텍스트(thewronghand)가 움직이며 표시되도록 적용
6. 로고의 width, height도 프롭으로 받도록 처리
7. header의 믹스블렌드모드가 특정 페이지에서만 적용되도록 수정