### PR TITLE
design: 블로그 페이지 모션 적용

### DIFF
--- a/src/Components/Blog/BlogIntro.tsx
+++ b/src/Components/Blog/BlogIntro.tsx
@@ -1,14 +1,23 @@
 import VitriolLogo from "./VitriolLogo";
 import Anchor from "../../utils/Anchor";
+import { motion } from "framer-motion";
 
 export default function BlogIntro() {
   return (
-    <section className="mx-16">
-      <section className="text-6xl flex items-center">
+    <motion.section
+      initial="hidden"
+      animate="visible"
+      variants={containerVariants}
+      className="mx-16"
+    >
+      <motion.section
+        variants={itemVariants}
+        className="text-6xl flex items-center"
+      >
         <VitriolLogo />
         <span className="ml-1 cursor-default">Vitriol</span>
-      </section>
-      <p className="mt-6">
+      </motion.section>
+      <motion.p variants={itemVariants} className="mt-6">
         Vitriol은 <Anchor href="https://obsidian.md/">Obsidian</Anchor>의
         Digital Garden 플러그인을 기반으로 한 개인 블로그입니다. 그래프와 관련된
         UI 상호작용을 원활히 관리하기 위해 React로 구성하였습니다.
@@ -31,7 +40,50 @@ export default function BlogIntro() {
           더 많은 옵시디언 고유 문법
         </Anchor>
         을 추가할 예정입니다.
-      </p>
-    </section>
+      </motion.p>
+    </motion.section>
   );
 }
+
+const containerVariants = {
+  hidden: {
+    opacity: 0,
+    y: -10,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -10,
+    transition: {
+      staggerChildren: 0.1,
+      staggerDirection: -1,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: {
+    opacity: 0,
+    y: -10,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.5,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -10,
+    transition: {
+      duration: 0.5,
+    },
+  },
+};

--- a/src/Components/Blog/VitriolLogo.tsx
+++ b/src/Components/Blog/VitriolLogo.tsx
@@ -7,7 +7,12 @@ export default function VitriolLogo() {
       height="50"
       xmlns="http://www.w3.org/2000/svg"
       animate={{ rotate: 360 }}
-      transition={{ delay: 1.8, duration: 2, ease: "linear", repeat: Infinity }}
+      transition={{
+        delay: 1.35,
+        duration: 2,
+        ease: "linear",
+        repeat: Infinity,
+      }}
     >
       <motion.g variants={containerVariants} initial="hidden" animate="visible">
         <motion.path

--- a/src/Components/Blog/VitriolLogo.tsx
+++ b/src/Components/Blog/VitriolLogo.tsx
@@ -1,18 +1,78 @@
+import { motion } from "framer-motion";
+
 export default function VitriolLogo() {
   return (
-    <svg
+    <motion.svg
       width="50"
       height="50"
-      viewBox="0 0 793 793"
-      fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      animate={{ rotate: 360 }}
+      transition={{ delay: 1.8, duration: 2, ease: "linear", repeat: Infinity }}
     >
-      <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
-        d="M793 396.5C793 615.481 615.481 793 396.5 793C177.519 793 0 615.481 0 396.5C0 177.519 177.519 0 396.5 0C615.481 0 793 177.519 793 396.5ZM342.375 680.073V113.287C208.863 138.547 107.891 255.822 107.891 396.68C107.891 537.538 208.863 654.812 342.375 680.073ZM679.713 450.625C657.759 566.662 566.302 658.119 450.266 680.073V450.625H679.713ZM679.713 342.734H450.266V113.287C566.302 135.241 657.759 226.698 679.713 342.734Z"
-        fill="currentcolor"
-      />
-    </svg>
+      <motion.g variants={containerVariants} initial="hidden" animate="visible">
+        <motion.path
+          d="M 25 5 A 20 20 0 0 1 25 45 A 20 20 0 0 1 25 5"
+          fill="none"
+          stroke="currentcolor"
+          strokeWidth="7"
+          variants={circleVariant}
+        />
+        <motion.line
+          x1="25"
+          y1="5"
+          x2="25"
+          y2="45"
+          stroke="currentcolor"
+          strokeWidth="7"
+          variants={verticalLineVariant}
+        />
+        <motion.line
+          x1="25"
+          y1="25"
+          x2="45"
+          y2="25"
+          stroke="currentcolor"
+          strokeWidth="7"
+          variants={horizontalLineVariant}
+        />
+      </motion.g>
+    </motion.svg>
   );
 }
+
+const circleVariant = {
+  hidden: {
+    pathLength: 0,
+    strokeLinecap: "butt" as const,
+    strokeDashoffset: 0.5,
+    strokeDasharray: 2,
+  },
+  visible: {
+    pathLength: 1,
+    strokeLinecap: "round" as const,
+    strokeDashoffset: 0,
+    transition: { duration: 0.9 },
+  },
+};
+
+const verticalLineVariant = {
+  hidden: { pathLength: 0, strokeLinecap: "butt" as const },
+  visible: {
+    pathLength: 1,
+    strokeLinecap: "round" as const,
+    transition: { delay: 0.5, duration: 0.5 },
+  },
+};
+
+const horizontalLineVariant = {
+  hidden: { pathLength: 0, strokeLinecap: "butt" as const },
+  visible: {
+    pathLength: 1,
+    strokeLinecap: "round" as const,
+    transition: { delay: 0.8, duration: 0.5 },
+  },
+};
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 1 } },
+};

--- a/src/Components/Projects/ProjectListImgSection.tsx
+++ b/src/Components/Projects/ProjectListImgSection.tsx
@@ -51,7 +51,7 @@ const containerVariants = {
 };
 
 const imageVariants = {
-  hidden: { y: "-30%", opacity: 0 },
+  hidden: { y: "-15%", opacity: 0 },
   show: {
     y: 0,
     opacity: 1,
@@ -59,7 +59,7 @@ const imageVariants = {
       delay: 0.2,
       duration: 0.5,
       type: "spring",
-      damping: 7,
+      damping: 10,
       stiffness: 100,
     },
   },

--- a/src/Pages/Blog.tsx
+++ b/src/Pages/Blog.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import BlogIntro from "../Components/Blog/BlogIntro";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
 
@@ -10,10 +11,19 @@ export default function Blog() {
       }`}
     >
       <BlogIntro />
-      <iframe
-        src="https://www.naver.com"
-        className="m-10 w-full h-3/5"
-      ></iframe>
+      <motion.div
+        className={`flex justify-center m-10 w-full h-[650px] ${
+          darkMode ? "bg-[#6C7A8F]" : "bg-gray-100"
+        }`}
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.6, duration: 0.5 }}
+      >
+        <iframe
+          src="https://www.naver.com"
+          className="w-full max-w-[1000px] h-full"
+        ></iframe>
+      </motion.div>
     </main>
   );
 }

--- a/src/Pages/Blog.tsx
+++ b/src/Pages/Blog.tsx
@@ -6,7 +6,7 @@ export default function Blog() {
   const darkMode = useDarkMode();
   return (
     <main
-      className={`w-screen h-screen flex flex-col justify-center items-center transition-all duration-300 ease-in-out ${
+      className={`pt-20 w-screen h-screen flex flex-col justify-center items-center transition-all duration-300 ease-in-out ${
         darkMode ? "text-white bg-slate-500" : "text-gray-700"
       }`}
     >


### PR DESCRIPTION
1. 로고에 애니메이션 적용 (그려진 후 빙글빙글 돌게 만듦)
2. 블로그인트로에 모션 적용
3. iframe에 모션 적용, max-w 설정으로 비율 조정함
4. 페이지에 pt 줘서 헤더 영역 침범하지 않게 함
5. 프로젝트리스트-이미지섹션의 로고 스프링 애니메이션이 너무 호들갑스러워서 얌전하게 만듦