### PR TITLE
design: 프로젝트 상세보기 페이지 디자인 작업

### DIFF
--- a/src/Components/About/Skills/MobileSkillList.tsx
+++ b/src/Components/About/Skills/MobileSkillList.tsx
@@ -39,7 +39,7 @@ export default function MobileSkillList({
             hover:border-blue-300 hover:bg-blue-300
             cursor-pointer p-[2px] m-[1px]
             px-2 rounded-lg border-[1px] ${
-              darkMode ? "border-[#6C7A8F]" : "border-gray-50"
+              darkMode ? "border-gray-500" : "border-gray-50"
             }
             transition-all duration-300 ease-in-out
             `}

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -7,6 +7,7 @@ import NavButton from "./NavButton";
 import Logo from "../Main/Logo";
 import { Link, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
+import { COLORS } from "../../utils/constant";
 
 export default function Header() {
   const location = useLocation();
@@ -25,7 +26,7 @@ export default function Header() {
       initial="hidden"
       animate="visible"
       className={`${
-        darkMode ? "text-white" : "text-gray-700"
+        darkMode ? COLORS.DARK_MODE_TEXT : COLORS.LIGHT_MODE_TEXT
       } fixed top-0 left-0 flex justify-between items-center w-full h-16 p-15 z-10 ${
         isSpecialPage && "mix-blend-difference"
       }`}

--- a/src/Components/Header/Nav.tsx
+++ b/src/Components/Header/Nav.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import NavItem from "./NavItem";
 import { useDarkMode } from "../../utils/hooks/useDarkMode";
+import { COLORS } from "../../utils/constant";
 
 export default function Nav() {
   const darkMode = useDarkMode();
@@ -8,7 +9,9 @@ export default function Nav() {
   return (
     <motion.div
       className={`${
-        darkMode ? "text-white bg-slate-500" : " text-gray-700 bg-white"
+        darkMode
+          ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+          : `${COLORS.LIGHT_MODE_BG_WHITE} ${COLORS.LIGHT_MODE_TEXT}`
       } flex justify-center items-center flex-col space-y-4  text-5xl w-screen h-screen z-10 fixed transition-all duration-300 ease-in-out`}
       variants={containerVariants}
       initial="hidden"

--- a/src/Components/ProjectDetails/ProjectImageList.tsx
+++ b/src/Components/ProjectDetails/ProjectImageList.tsx
@@ -4,12 +4,17 @@ interface ProjectImageListProps {
 
 export default function ProjectImageList({ imgs }: ProjectImageListProps) {
   return (
-    <ul>
-      {imgs.map((item: string, index) => (
-        <li key={index}>
-          <img src={item} alt={String(index)} />
-        </li>
-      ))}
-    </ul>
+    <section className=" mb-32">
+      <section className="text-3xl pt-4 pb-2 border-b-2 border-solid mb-4">
+        Sample Images
+      </section>
+      <ul className="px-6">
+        {imgs.map((item: string, index) => (
+          <li key={index} className="my-4 shadow-md rounded-xl overflow-hidden">
+            <img src={item} alt={String(index)} />
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/src/Components/ProjectDetails/ProjectInfoContainer.tsx
+++ b/src/Components/ProjectDetails/ProjectInfoContainer.tsx
@@ -1,0 +1,75 @@
+import { Link } from "react-router-dom";
+import { Project } from "../../types";
+
+export default function ProjectInfoContainer({
+  data,
+}: ProjectInfoContainerProps) {
+  return (
+    <section className="">
+      <section className="text-3xl pt-6 pb-4 border-solid border-b-2 mb-4 cursor-default">
+        {data.title}
+      </section>
+      <section className="text-xl text-right mb-2 pr-2 cursor-default">
+        {data.type}
+      </section>
+      <section className="pb-2">{data.description}</section>
+      <ul className="flex flex-wrap content-start mb-2">
+        {data.stacks.map((item) => (
+          <li
+            style={{ background: data.secondaryColor }}
+            className={`mt-2 text-white py-1 px-3 mr-1 rounded-2xl cursor-default`}
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+      <div>
+        {data && data.docsUrls && (
+          <div className="flex">
+            <span className="cursor-default mr-2 text-lg">Docs</span>
+            <ul className="pt-[2px] ml-6 list-disc">
+              {data.docsUrls.map((item) => (
+                <li
+                  key={item.title}
+                  className="hover:text-blue-300 transition-all ease-in-out duration-300s"
+                >
+                  <a href={item.url} target="_blank" rel="noopener noreferrer">
+                    {item.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      <section className="flex items-center mt-1">
+        <span className="cursor-default mr-2 text-lg">Links</span>
+        <ul className="flex px-2">
+          <li className="px-3 py-1 rounded-2xl bg-blue-300 hover:bg-blue-200 transition-all duration-300 ease-in-out mr-1">
+            <a href={data.deployUrl} target="_blank" rel="noopener noreferrer">
+              배포링크
+            </a>
+          </li>
+          <li className="px-3 py-1 rounded-2xl bg-blue-300 hover:bg-blue-200 transition-all duration-300 ease-in-out">
+            <a href={data.gitHubUrl} target="_blank" rel="noopener noreferrer">
+              깃허브 링크
+            </a>
+          </li>
+        </ul>
+      </section>
+      <section className=" flex justify-end items-center mt-6">
+        <span className="text-2xl mr-4">Next Project</span>
+        <Link
+          to={`/projects/${data.nextProject.path}`}
+          className="mt-1 text-lg hover:text-blue-300 transition-all ease-in-out duration-300"
+        >
+          {data.nextProject.title}
+        </Link>
+      </section>
+    </section>
+  );
+}
+
+interface ProjectInfoContainerProps {
+  data: Project;
+}

--- a/src/Components/ProjectDetails/ProjectThumbnail.tsx
+++ b/src/Components/ProjectDetails/ProjectThumbnail.tsx
@@ -1,0 +1,70 @@
+import { motion } from "framer-motion";
+
+export default function ProjectThumbnail({
+  bgColor,
+  image,
+}: ProjectThumbnailProps) {
+  return (
+    <motion.section
+      initial="hidden"
+      animate="visible"
+      variants={containerVariants}
+      className=""
+    >
+      <section
+        style={{ background: bgColor }}
+        className="shadow-lg rounded-2xl aspect-auto flex justify-center items-center p-10"
+      >
+        <motion.img
+          src={image}
+          alt="thumbnail"
+          initial="hidden"
+          animate="visible"
+          variants={imgVariants}
+          className="sm:w-3/5 lg:w-2/5"
+        />
+      </section>
+    </motion.section>
+  );
+}
+
+interface ProjectThumbnailProps {
+  bgColor: string;
+  image: string;
+}
+
+const containerVariants = {
+  hidden: {
+    opacity: 0,
+    y: -30,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: 0.7,
+      duration: 0.5,
+      type: "spring",
+      damping: 10,
+      stiffness: 100,
+    },
+  },
+};
+
+const imgVariants = {
+  hidden: {
+    opacity: 0,
+    y: -30,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: 0.4,
+      duration: 0.5,
+      type: "spring",
+      damping: 9,
+      stiffness: 100,
+    },
+  },
+};

--- a/src/Pages/About.tsx
+++ b/src/Pages/About.tsx
@@ -8,6 +8,7 @@ import ContactContainer from "../Components/About/Contacts/ContactsContainer";
 import { useCacheSkillImages } from "../utils/hooks/useCacheSkillImages";
 import { motion, AnimatePresence } from "framer-motion";
 import { useMediaQuery } from "../utils/hooks/useMediaQuery";
+import { COLORS } from "../utils/constant";
 
 export default function About() {
   const darkMode = useDarkMode();
@@ -33,7 +34,9 @@ export default function About() {
     <AnimatePresence>
       <motion.div
         className={`${
-          darkMode ? "text-white bg-slate-500" : "text-gray-700"
+          darkMode
+            ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+            : `${COLORS.LIGHT_MODE_BG} ${COLORS.LIGHT_MODE_TEXT}`
         } transition-all duration-300 ease-in-out pt-10 xl:pt-0 min-h-screen`}
         initial="hidden"
         animate="visible"

--- a/src/Pages/Blog.tsx
+++ b/src/Pages/Blog.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import BlogIntro from "../Components/Blog/BlogIntro";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
 import { useEffect } from "react";
+import { COLORS } from "../utils/constant";
 
 export default function Blog() {
   const darkMode = useDarkMode();
@@ -12,13 +13,15 @@ export default function Blog() {
   return (
     <main
       className={`min-h-screen pt-20 flex flex-col justify-center items-center transition-all duration-300 ease-in-out ${
-        darkMode ? "text-white bg-slate-500" : "text-gray-700"
+        darkMode
+          ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+          : `${COLORS.LIGHT_MODE_BG} ${COLORS.LIGHT_MODE_TEXT}`
       }`}
     >
       <BlogIntro />
       <motion.div
         className={`flex justify-center m-10 w-full h-[1000px] md:h-[650px] ${
-          darkMode ? "bg-[#6C7A8F]" : "bg-gray-100"
+          darkMode ? "bg-gray-500" : "bg-gray-100"
         }`}
         initial={{ opacity: 0, y: -10 }}
         animate={{ opacity: 1, y: 0 }}

--- a/src/Pages/Main.tsx
+++ b/src/Pages/Main.tsx
@@ -1,4 +1,5 @@
 import Logo from "../Components/Main/Logo";
+import { COLORS } from "../utils/constant";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
 
 export default function Main() {
@@ -7,7 +8,9 @@ export default function Main() {
   return (
     <div
       className={`${
-        darkMode ? "text-white bg-slate-500" : "text-gray-700"
+        darkMode
+          ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+          : `${COLORS.LIGHT_MODE_BG} ${COLORS.LIGHT_MODE_TEXT}`
       } w-screen h-screen flex flex-col justify-center items-center transition-all duration-300 ease-in-out`}
     >
       <Logo

--- a/src/Pages/ProjectDetails.tsx
+++ b/src/Pages/ProjectDetails.tsx
@@ -3,6 +3,10 @@ import useFetchDocument from "../utils/hooks/useFetchDocument";
 import { Project } from "../types";
 import { useCacheProjectImages } from "../utils/hooks/useCacheSkillImages";
 import { useDarkMode } from "../utils/hooks/useDarkMode";
+import ProjectImageList from "../Components/ProjectDetails/ProjectImageList";
+import ProjectThumbnail from "../Components/ProjectDetails/ProjectThumbnail";
+import ProjectInfoContainer from "../Components/ProjectDetails/ProjectInfoContainer";
+import { COLORS } from "../utils/constant";
 
 export default function ProjectDetails() {
   const darkMode = useDarkMode();
@@ -15,55 +19,24 @@ export default function ProjectDetails() {
 
   return (
     <main
-      className={` transition-all duration-300 ease-in-out ${
-        darkMode ? "text-white bg-slate-500" : "text-gray-700"
+      className={` pt-16 transition-all duration-300 ease-in-out ${
+        darkMode
+          ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+          : `${COLORS.LIGHT_MODE_BG} ${COLORS.LIGHT_MODE_TEXT}`
       }`}
     >
-      {loading && <div>Loading...</div>}
       {error && <div>Error: {error.message}</div>}
-      {data && (
-        <>
-          <>{data.title}</>
-          <>{data.type}</>
-          <div
-            className="flex justify-center items-center w-48 aspect-square"
-            style={{ backgroundColor: `${data.thumbnailBgColor}` }}
-          >
-            <img src={data.thumbnailLogo} alt={data.id} />
-          </div>
-          <>{data.description}</>
-          <>
-            {data.stacks.map((item) => (
-              <div>{item}</div>
-            ))}
-          </>
-          <div>
-            <div>문서주소</div>
-            {data.docsUrls.map((item) => (
-              <a href={item.url} target="_blank">
-                {item.title}
-              </a>
-            ))}
-          </div>
-
-          <div>
-            <a href={data.deployUrl} target="_blank">
-              배포링크
-            </a>
-          </div>
-
-          <div>
-            <a href={data.gitHubUrl} target="_blank">
-              깃허브 링크
-            </a>
-          </div>
-
-          <>
-            {data.imgs.map((url, index) => (
-              <img src={url} alt={`${index}`} />
-            ))}
-          </>
-        </>
+      {!loading && !error && data && (
+        <section className="px-14 md:px-28 lg:px-36 xl:px-48 2xl:px-56 3xl:px-64 ">
+          <section className="min-h-[400px] md:min-h-[360px] md:-mt-20">
+            <ProjectThumbnail
+              bgColor={data.thumbnailBgColor}
+              image={data.thumbnailLogo}
+            />
+          </section>
+          <ProjectInfoContainer data={data} />
+          <ProjectImageList imgs={data.imgs} />
+        </section>
       )}
     </main>
   );

--- a/src/Pages/Projects.tsx
+++ b/src/Pages/Projects.tsx
@@ -3,6 +3,7 @@ import useFetchCollection from "../utils/hooks/useFetchCollection";
 import { Project } from "../types";
 import ProjectList from "../Components/Projects/ProjectList";
 import { useCacheProjectThumbnails } from "../utils/hooks/useCacheSkillImages";
+import { COLORS } from "../utils/constant";
 
 export default function Projects() {
   const darkMode = useDarkMode();
@@ -12,7 +13,9 @@ export default function Projects() {
   return (
     <div
       className={`${
-        darkMode ? "text-white bg-slate-500" : "text-gray-700"
+        darkMode
+          ? `${COLORS.DARK_MODE_BG} ${COLORS.DARK_MODE_TEXT}`
+          : `${COLORS.LIGHT_MODE_BG} ${COLORS.LIGHT_MODE_TEXT}`
       } transition-all duration-300 ease-in-out`}
     >
       <section className="w-screen h-screen flex flex-col justify-center items-center">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,14 +25,21 @@ export interface Project {
   id: string;
   title: string;
   thumbnailBgColor: string;
+  secondaryColor: string;
   thumbnailLogo: string;
   type: string;
   imgs: Array<string>;
   stacks: Array<string>;
   description: string;
-  docsUrls: DocUrl[];
+  docsUrls?: DocUrl[];
   deployUrl: string;
   gitHubUrl: string;
+  nextProject: NextProject;
+}
+
+interface NextProject {
+  title: string;
+  path: string;
 }
 
 export interface Profile {

--- a/src/utils/constant/index.ts
+++ b/src/utils/constant/index.ts
@@ -1,0 +1,7 @@
+export const COLORS = {
+  DARK_MODE_BG: "bg-gray-600",
+  DARK_MODE_TEXT: "text-white",
+  LIGHT_MODE_BG: "bg-none",
+  LIGHT_MODE_BG_WHITE: "bg-white",
+  LIGHT_MODE_TEXT: "text-gray-700",
+};


### PR DESCRIPTION
1. 프로젝트 디테일 페이지 내 컴포넌트 분리 (썸네일, 인포컨테이너, 이미지리스트) 및 디자인 작업
2. 세컨더리 컬러, 넥스트 프로젝트 등 필요한 데이터 추가에 따라 Project 타입 정의 수정
3. 다크모드 컬러를 slate에서 gray로 변경
4. 상수 변수 관리 파일 생성 + 컬러 상수 변수 정의
5. 프로젝트 상세보기 페이지 반응형 작업 일부 (맥 화면이 작아서 xl 이상부터는 확인이 어려워 lg정도까지만 작업함. 집에 가서 이어서 할 것)