### PR TITLE
fix: 다크모드와 관련된 그레인 필터의 문제 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import "./index.css";
 import { Route, Routes } from "react-router-dom";
-import { useGrain } from "./utils/hooks/useGrain";
-import { useDarkMode } from "./utils/hooks/useDarkMode";
 
 import Main from "./Pages/Main";
 import About from "./Pages/About";
@@ -14,19 +12,15 @@ import { RootState } from "./redux/store";
 import ProjectDetails from "./Pages/ProjectDetails";
 import Blog from "./Pages/Blog";
 import AppSettingsWrapper from "./utils/AppSettingsWrapper";
+import DarkModeGrainCanvas from "./Components/Global/DarkModeGrainCanvas";
 
 function App() {
-  const darkMode = useDarkMode();
-  const canvasRef = useGrain(darkMode);
   const isOpen = useSelector((state: RootState) => state.menu.isOpen);
 
   return (
     <div className="w-full h-full">
       <AppSettingsWrapper>
-        <canvas
-          ref={canvasRef}
-          className="fixed top-0 left-0 w-screen h-screen z-50 opacity-5 pointer-events-none"
-        />
+        <DarkModeGrainCanvas />
 
         <AnimatePresence>{isOpen && <Nav key="nav" />}</AnimatePresence>
 

--- a/src/Components/About/Contacts/ContactsItem.tsx
+++ b/src/Components/About/Contacts/ContactsItem.tsx
@@ -7,7 +7,7 @@ function ListItem({ title, children, isMisc = false }: ListItemProps) {
   if (!isMisc)
     return (
       <li className="flex items-center mx-2">
-        <section className="mr-2 text-3xl py-4 pr-2 border-r-2 border-r-current cursor-default min-w-[98px]">
+        <section className="mr-2 text-3xl py-4 pr-2 border-r-2 border-r-current cursor-default min-w-[102px]">
           {title}
         </section>
         <section className="text-xl min-w-[206px]">
@@ -45,7 +45,7 @@ function ListItem({ title, children, isMisc = false }: ListItemProps) {
     );
   return (
     <li className="flex items-center mx-2">
-      <section className="mr-2 text-3xl py-4 pr-2 border-r-2 border-r-current cursor-default min-w-[98px]">
+      <section className="mr-2 text-3xl py-4 pr-2 border-r-2 border-r-current cursor-default min-w-[102px]">
         {title}
       </section>
       <section className="text-xl min-w-[206px]">{children}</section>

--- a/src/Components/Global/DarkModeGrainCanvas.tsx
+++ b/src/Components/Global/DarkModeGrainCanvas.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useDarkMode } from "../../utils/hooks/useDarkMode";
+import { useGrain } from "../../utils/hooks/useGrain";
+
+export default function DarkModeGrainCanvas() {
+  const darkMode = useDarkMode();
+  const canvasRef = useGrain();
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      canvasRef.current.style.filter = darkMode ? "invert(1)" : "invert(0)";
+    }
+  }, [darkMode, canvasRef]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="fixed top-0 left-0 w-screen h-screen opacity-5 z-50 pointer-events-none"
+    />
+  );
+}

--- a/src/utils/hooks/useGrain.ts
+++ b/src/utils/hooks/useGrain.ts
@@ -3,13 +3,12 @@ import { useEffect, useRef } from "react";
 const createNoise = (
   ctx: CanvasRenderingContext2D,
   wWidth: number,
-  wHeight: number,
-  darkMode: boolean
+  wHeight: number
 ): ImageData => {
   const iData = ctx.createImageData(wWidth, wHeight);
   const buffer32 = new Uint32Array(iData.data.buffer);
   const len = buffer32.length;
-  const color = darkMode ? 0xffffffff : 0xff000000; // 흰색 또는 검은색
+  const color = 0xff000000;
 
   for (let i = 0; i < len; i++) {
     if (Math.random() < 0.1) {
@@ -20,7 +19,7 @@ const createNoise = (
   return iData;
 };
 
-export const useGrain = (darkMode: boolean) => {
+export const useGrain = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   useEffect(() => {
     const canvas = canvasRef.current!;
@@ -53,7 +52,7 @@ export const useGrain = (darkMode: boolean) => {
 
       noiseData = [];
       for (let i = 0; i < 10; i++) {
-        noiseData.push(createNoise(ctx, wWidth, wHeight, darkMode));
+        noiseData.push(createNoise(ctx, wWidth, wHeight));
       }
 
       clearTimeout(loopTimeout);
@@ -72,7 +71,7 @@ export const useGrain = (darkMode: boolean) => {
       window.removeEventListener("resize", handleResize);
       clearTimeout(loopTimeout);
     };
-  }, [darkMode]);
+  }, []);
 
   return canvasRef;
 };


### PR DESCRIPTION
1. 기존의 useGrain 훅은 다크모드가 변경될 때 기존의 노이즈 데이터를 삭제하고 새로운 색상의 새로운 노이즈 데이터를 생성, 새 애니메이션을 재생하는데, 다크모드를 여러 번 토글하면 노이즈의 색상과 애니메이션이 여러 번 초기화되며 화면이 깜빡이는 것처럼 보이는 증상이 있었음
2. useGrain이 항상 검은색 노이즈를 생성하고 애니메이션을 수행하도록 수정
3. DarkModeGrainCanvas 컴포넌트를 생성하고, 이 컴포넌트 내에서 다크모드 여부에 따라 canvas에 invert (색상을 반대로 바꿈)를 적용하게끔 수정함
4. 다크모드 관련 로직과 grain 노이즈 생성, 애니메이션 수행 로직이 완전히 분리되어 문제를 해결함